### PR TITLE
fix id parsing regex

### DIFF
--- a/IMDb.cs
+++ b/IMDb.cs
@@ -94,7 +94,7 @@ namespace IMDb_Scraper
         private void parseIMDbPage(string imdbUrl, bool GetExtraInfo)
         {
             string html = getUrlData(imdbUrl+"combined");
-            Id = match(@"<link rel=""canonical"" href=""http://www.imdb.com/title/(tt\d{7})/combined"" />", html);
+            Id = match(@"<link rel=""canonical"" href=""http://www.imdb.com/title/(tt\d{7})/[^\d]*?"" />", html);
             if (!string.IsNullOrEmpty(Id))
             {
                 status = true;


### PR DESCRIPTION
Apparently the website's code changed, this is just a minor fix for the id recognition.
The whole class may need to be rewritten, regex is not appropriate for these types of work.

Must use xpath parsing etc.